### PR TITLE
Fix localhost typo

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,7 +14,7 @@ function createWindow() {
     });
 
     if (isDev) {
-        win.loadURL('http://loaclhost:3000');
+        win.loadURL('http://localhost:3000');
         win.webContents.openDevTools();
     } else {
         win.loadFile(path.join(__dirname, '../renderer/index.html'));


### PR DESCRIPTION
## Summary
- correct the development URL typo in `electron/main.ts`

## Testing
- `npx tsc -p electron/tsconfig.json > /tmp/tsc.log`
- `npx electron electron/main.js` *(fails: command not found due to missing binary)*