### PR TITLE
Add XML save and open features

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,5 +1,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld('api', {
-    ping: () => ipcRenderer.invoke('ping')
+    ping: () => ipcRenderer.invoke('ping'),
+    saveXML: (xml: string) => ipcRenderer.invoke('save-xml', xml),
+    openXML: () => ipcRenderer.invoke('open-xml')
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,11 @@
+export {};
+
+declare global {
+  interface Window {
+    api: {
+      saveXML: (xml: string) => Promise<{ canceled: boolean; filePath?: string }>;
+      openXML: () => Promise<{ canceled: boolean; data: string | null }>;
+      ping: () => Promise<any>;
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- implement IPC in the Electron main process for saving/opening XML
- expose saveXML/openXML methods in the preload script
- add TypeScript declaration for `window.api`
- enable diagram save/load buttons in React component

## Testing
- `npm run lint` *(fails: `next` not found)*